### PR TITLE
disable automatic rebase for non-automerging PRs

### DIFF
--- a/base.json
+++ b/base.json
@@ -14,6 +14,9 @@
 
   "stabilityDays": 3,
 
+  "rebaseWhen$comment": "set this to 'never' to reduce CI load; add 'rebase' label to tell Renovate to rebase",
+  "rebaseWhen": "never",
+
   "labels": ["dependencies"],
 
   "vulnerabilityAlerts": {

--- a/conservative.json
+++ b/conservative.json
@@ -17,7 +17,8 @@
         "git@github.com:LLK/",
         "https://github.com/LLK/"
       ],
-      "automerge": true
+      "automerge": true,
+      "rebaseWhen": "behind-base-branch"
     },
     {
       "$comment": "enable auto-merge for all updates of LLK packages which don't yet use semver",
@@ -29,7 +30,8 @@
         "git@github.com:LLK/",
         "https://github.com/LLK/"
       ],
-      "automerge": true
+      "automerge": true,
+      "rebaseWhen": "behind-base-branch"
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -10,7 +10,8 @@
       "$comment": "enable auto-merge for minor & patch updates of all packages which use semver",
       "matchCurrentVersion": "!/^0/",
       "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "automerge": true,
+      "rebaseWhen": "behind-base-branch"
     },
     {
       "$comment": "enable auto-merge for all updates of LLK packages which don't yet use semver",
@@ -22,7 +23,8 @@
         "git@github.com:LLK/",
         "https://github.com/LLK/"
       ],
-      "automerge": true
+      "automerge": true,
+      "rebaseWhen": "behind-base-branch"
     }
   ]
 }


### PR DESCRIPTION
### Resolves

Resolves #1 

### Proposed Changes

This change sets `rebaseWhen` to `never` for "all" PRs, then overrides that with `behind-base-branch` for auto-merge PRs.

### Reason for Changes

Our Renovate PRs tend to rebase & rebuild frequently, causing unnecessary load on CI.

Renovate's `rebaseWhen` setting defaults to `auto`, which means:

- if the repo/branch requires PRs to be up-to-date before merging, then rebase when the PR is behind the target branch
- otherwise, rebase when there is a conflict

Many (but not all) of our repositories are configured with branch protection rules preventing out-of-date PRs from being merged, leading to the maximum possible churn. Even in repositories which aren't configured that way, `package-lock.json` changes conflict frequently so the PRs tend to rebase almost as often.

This change means:

- for non-auto-merging PRs, we will never automatically rebase. Adding the "rebase" label will cause Renovate to rebase the PR.
- auto-merging PRs will always rebase when behind the target branch, regardless of GitHub branch protection settings. This ensures that we won't end up with an untested combination of updates if two Renoate PRs are ready at about the same time.

See also: https://docs.renovatebot.com/configuration-options/#rebasewhen